### PR TITLE
Change go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/terraform-plugin-go
+module github.com/pulumi/terraform-plugin-go
 
 go 1.19
 

--- a/internal/logging/protocol_data.go
+++ b/internal/logging/protocol_data.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 )
 
 const (

--- a/script/renamemod.sh
+++ b/script/renamemod.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+OLD_MODULE="$1"
+NEW_MODULE="$2"
+
+find . -type f -name '*.go' \
+     -exec sed -i -e "s,$OLD_MODULE,$NEW_MODULE,g" {} \;

--- a/tfprotov5/diagnostic.go
+++ b/tfprotov5/diagnostic.go
@@ -1,6 +1,6 @@
 package tfprotov5
 
-import "github.com/hashicorp/terraform-plugin-go/tftypes"
+import "github.com/pulumi/terraform-plugin-go/tftypes"
 
 const (
 	// DiagnosticSeverityInvalid is used to indicate an invalid

--- a/tfprotov5/dynamic_value.go
+++ b/tfprotov5/dynamic_value.go
@@ -3,7 +3,7 @@ package tfprotov5
 import (
 	"errors"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 // ErrUnknownDynamicValueType is returned when a DynamicValue has no MsgPack or

--- a/tfprotov5/internal/diag/diagnostics.go
+++ b/tfprotov5/internal/diag/diagnostics.go
@@ -3,8 +3,8 @@ package diag
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 )
 
 // Diagnostics is a collection of Diagnostic.

--- a/tfprotov5/internal/diag/diagnostics_test.go
+++ b/tfprotov5/internal/diag/diagnostics_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/diag"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5/internal/diag"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklogtest"
 )

--- a/tfprotov5/internal/fromproto/attribute_path.go
+++ b/tfprotov5/internal/fromproto/attribute_path.go
@@ -3,7 +3,7 @@ package fromproto
 import (
 	"errors"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/fromproto/data_source.go
+++ b/tfprotov5/internal/fromproto/data_source.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/fromproto/diagnostic.go
+++ b/tfprotov5/internal/fromproto/diagnostic.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/fromproto/provider.go
+++ b/tfprotov5/internal/fromproto/provider.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/fromproto/resource.go
+++ b/tfprotov5/internal/fromproto/resource.go
@@ -3,7 +3,7 @@ package fromproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/fromproto/schema.go
+++ b/tfprotov5/internal/fromproto/schema.go
@@ -3,8 +3,8 @@ package fromproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/fromproto/state.go
+++ b/tfprotov5/internal/fromproto/state.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/fromproto/string_kind.go
+++ b/tfprotov5/internal/fromproto/string_kind.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/fromproto/types.go
+++ b/tfprotov5/internal/fromproto/types.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/tf5serverlogging/downstream_request.go
+++ b/tfprotov5/internal/tf5serverlogging/downstream_request.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/diag"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5/internal/diag"
 )
 
 // DownstreamRequest sets a request duration start time context key and

--- a/tfprotov5/internal/tf5serverlogging/downstream_request_test.go
+++ b/tfprotov5/internal/tf5serverlogging/downstream_request_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/diag"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tf5serverlogging"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5/internal/diag"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5/internal/tf5serverlogging"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklogtest"
 )

--- a/tfprotov5/internal/toproto/attribute_path.go
+++ b/tfprotov5/internal/toproto/attribute_path.go
@@ -3,7 +3,7 @@ package toproto
 import (
 	"errors"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/toproto/data_source.go
+++ b/tfprotov5/internal/toproto/data_source.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/toproto/diagnostic.go
+++ b/tfprotov5/internal/toproto/diagnostic.go
@@ -3,7 +3,7 @@ package toproto
 import (
 	"unicode/utf8"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/toproto/dynamic_value.go
+++ b/tfprotov5/internal/toproto/dynamic_value.go
@@ -3,8 +3,8 @@ package toproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/toproto/provider.go
+++ b/tfprotov5/internal/toproto/provider.go
@@ -3,7 +3,7 @@ package toproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/toproto/resource.go
+++ b/tfprotov5/internal/toproto/resource.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/toproto/schema.go
+++ b/tfprotov5/internal/toproto/schema.go
@@ -3,7 +3,7 @@ package toproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/toproto/server_capabilities.go
+++ b/tfprotov5/internal/toproto/server_capabilities.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/toproto/state.go
+++ b/tfprotov5/internal/toproto/state.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/internal/toproto/string_kind.go
+++ b/tfprotov5/internal/toproto/string_kind.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 )
 

--- a/tfprotov5/resource.go
+++ b/tfprotov5/resource.go
@@ -3,7 +3,7 @@ package tfprotov5
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 // ResourceServer is an interface containing the methods a resource

--- a/tfprotov5/schema.go
+++ b/tfprotov5/schema.go
@@ -1,6 +1,6 @@
 package tfprotov5
 
-import "github.com/hashicorp/terraform-plugin-go/tftypes"
+import "github.com/pulumi/terraform-plugin-go/tftypes"
 
 const (
 	// SchemaNestedBlockNestingModeInvalid indicates that the nesting mode

--- a/tfprotov5/schema_test.go
+++ b/tfprotov5/schema_test.go
@@ -3,8 +3,8 @@ package tfprotov5_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 func TestSchemaAttributeValueType(t *testing.T) {

--- a/tfprotov5/state.go
+++ b/tfprotov5/state.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 // ErrUnknownRawStateType is returned when a RawState has no Flatmap or JSON

--- a/tfprotov5/state_test.go
+++ b/tfprotov5/state_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 func TestRawStateUnmarshalWithOpts(t *testing.T) {

--- a/tfprotov5/tf5server/plugin.go
+++ b/tfprotov5/tf5server/plugin.go
@@ -6,7 +6,7 @@ import (
 	"net/rpc"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 	"google.golang.org/grpc"
 )

--- a/tfprotov5/tf5server/server.go
+++ b/tfprotov5/tf5server/server.go
@@ -13,11 +13,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/fromproto"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tf5serverlogging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/toproto"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5/internal/fromproto"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5/internal/tf5serverlogging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov5/internal/toproto"
 	"github.com/pulumi/terraform/pkg/tfplugin5"
 	"google.golang.org/grpc"
 

--- a/tfprotov6/diagnostic.go
+++ b/tfprotov6/diagnostic.go
@@ -1,6 +1,6 @@
 package tfprotov6
 
-import "github.com/hashicorp/terraform-plugin-go/tftypes"
+import "github.com/pulumi/terraform-plugin-go/tftypes"
 
 const (
 	// DiagnosticSeverityInvalid is used to indicate an invalid

--- a/tfprotov6/dynamic_value.go
+++ b/tfprotov6/dynamic_value.go
@@ -3,7 +3,7 @@ package tfprotov6
 import (
 	"errors"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 // ErrUnknownDynamicValueType is returned when a DynamicValue has no MsgPack or

--- a/tfprotov6/internal/diag/diagnostics.go
+++ b/tfprotov6/internal/diag/diagnostics.go
@@ -3,8 +3,8 @@ package diag
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 )
 
 // Diagnostics is a collection of Diagnostic.

--- a/tfprotov6/internal/diag/diagnostics_test.go
+++ b/tfprotov6/internal/diag/diagnostics_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/diag"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6/internal/diag"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklogtest"
 )

--- a/tfprotov6/internal/fromproto/attribute_path.go
+++ b/tfprotov6/internal/fromproto/attribute_path.go
@@ -3,7 +3,7 @@ package fromproto
 import (
 	"errors"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/fromproto/data_source.go
+++ b/tfprotov6/internal/fromproto/data_source.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/fromproto/diagnostic.go
+++ b/tfprotov6/internal/fromproto/diagnostic.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/fromproto/provider.go
+++ b/tfprotov6/internal/fromproto/provider.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/fromproto/resource.go
+++ b/tfprotov6/internal/fromproto/resource.go
@@ -3,7 +3,7 @@ package fromproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/fromproto/schema.go
+++ b/tfprotov6/internal/fromproto/schema.go
@@ -3,8 +3,8 @@ package fromproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/fromproto/state.go
+++ b/tfprotov6/internal/fromproto/state.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/fromproto/string_kind.go
+++ b/tfprotov6/internal/fromproto/string_kind.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/fromproto/types.go
+++ b/tfprotov6/internal/fromproto/types.go
@@ -1,7 +1,7 @@
 package fromproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/tf6serverlogging/downstream_request.go
+++ b/tfprotov6/internal/tf6serverlogging/downstream_request.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/diag"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6/internal/diag"
 )
 
 // DownstreamRequest sets a request duration start time context key and

--- a/tfprotov6/internal/tf6serverlogging/downstream_request_test.go
+++ b/tfprotov6/internal/tf6serverlogging/downstream_request_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/diag"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tf6serverlogging"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6/internal/diag"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6/internal/tf6serverlogging"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklogtest"
 )

--- a/tfprotov6/internal/toproto/attribute_path.go
+++ b/tfprotov6/internal/toproto/attribute_path.go
@@ -3,7 +3,7 @@ package toproto
 import (
 	"errors"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/toproto/data_source.go
+++ b/tfprotov6/internal/toproto/data_source.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/toproto/diagnostic.go
+++ b/tfprotov6/internal/toproto/diagnostic.go
@@ -3,7 +3,7 @@ package toproto
 import (
 	"unicode/utf8"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/toproto/dynamic_value.go
+++ b/tfprotov6/internal/toproto/dynamic_value.go
@@ -3,8 +3,8 @@ package toproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/toproto/provider.go
+++ b/tfprotov6/internal/toproto/provider.go
@@ -3,7 +3,7 @@ package toproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/toproto/resource.go
+++ b/tfprotov6/internal/toproto/resource.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/toproto/schema.go
+++ b/tfprotov6/internal/toproto/schema.go
@@ -3,7 +3,7 @@ package toproto
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/toproto/server_capabilities.go
+++ b/tfprotov6/internal/toproto/server_capabilities.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/toproto/state.go
+++ b/tfprotov6/internal/toproto/state.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/internal/toproto/string_kind.go
+++ b/tfprotov6/internal/toproto/string_kind.go
@@ -1,7 +1,7 @@
 package toproto
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 )
 

--- a/tfprotov6/resource.go
+++ b/tfprotov6/resource.go
@@ -3,7 +3,7 @@ package tfprotov6
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 // ResourceServer is an interface containing the methods a resource

--- a/tfprotov6/schema.go
+++ b/tfprotov6/schema.go
@@ -1,6 +1,6 @@
 package tfprotov6
 
-import "github.com/hashicorp/terraform-plugin-go/tftypes"
+import "github.com/pulumi/terraform-plugin-go/tftypes"
 
 const (
 	// SchemaNestedBlockNestingModeInvalid indicates that the nesting mode

--- a/tfprotov6/schema_test.go
+++ b/tfprotov6/schema_test.go
@@ -3,8 +3,8 @@ package tfprotov6_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 func TestSchemaAttributeValueType(t *testing.T) {

--- a/tfprotov6/state.go
+++ b/tfprotov6/state.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 // ErrUnknownRawStateType is returned when a RawState has no Flatmap or JSON

--- a/tfprotov6/state_test.go
+++ b/tfprotov6/state_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 func TestRawStateUnmarshalWithOpts(t *testing.T) {

--- a/tfprotov6/tf6server/plugin.go
+++ b/tfprotov6/tf6server/plugin.go
@@ -6,7 +6,7 @@ import (
 	"net/rpc"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 	"google.golang.org/grpc"
 )

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -13,11 +13,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-go/internal/logging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/fromproto"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tf6serverlogging"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/toproto"
+	"github.com/pulumi/terraform-plugin-go/internal/logging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6/internal/fromproto"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6/internal/tf6serverlogging"
+	"github.com/pulumi/terraform-plugin-go/tfprotov6/internal/toproto"
 	"github.com/pulumi/terraform/pkg/tfplugin6"
 	"google.golang.org/grpc"
 

--- a/tftypes/value_example_test.go
+++ b/tftypes/value_example_test.go
@@ -3,7 +3,7 @@ package tftypes_test
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/terraform-plugin-go/tftypes"
 )
 
 func ExampleValue_As_string() {


### PR DESCRIPTION
Changes to module github.com/pulumi/terraform-plugin-go to disambiguate the fork from the original unmodified module.